### PR TITLE
Update default rook-ceph data path

### DIFF
--- a/pkg/controller/master/managedaddon/managed_addon_controller_test.go
+++ b/pkg/controller/master/managedaddon/managed_addon_controller_test.go
@@ -39,7 +39,7 @@ configOverride:
 cephClusterSpec:
   cephVersion:
     image: quay.io/ceph/ceph:v18.2.4
-  dataDirHostPath: /var/lib/llmos/rook
+  dataDirHostPath: /var/lib/llmos/rook-ceph
   mon:
     count: 3
     allowMultiplePerNode: false

--- a/pkg/template/templates/addons/llmos-ceph-cluster.yaml
+++ b/pkg/template/templates/addons/llmos-ceph-cluster.yaml
@@ -45,7 +45,7 @@ spec:
 
       # The path on the host where configuration files will be persisted. Must be specified.
       # Important: if you reinstall the cluster, make sure you delete this directory from each host or else the mons will fail to start on the new cluster.
-      dataDirHostPath: /var/lib/llmos/rook
+      dataDirHostPath: /var/lib/llmos/rook-ceph
 
       mon:
         count: 3 # default to 2 on cluster-init


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Description:**
Update default rook-ceph host data path to `/var/lib/llmos/rook-ceph`