### PR TITLE
Support clean up pvc on remove

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -57,6 +57,7 @@ const (
 	AnnotationVolumeClaimTemplates     = LLMOSPrefix + "/volume-claim-templates"
 	AnnotationClusterPolicyProviderKey = LLMOSPrefix + "/k8s-provider"
 	AnnotationSkipWebhook              = LLMOSPrefix + "/skip-webhook"
+	AnnotationOnDeleteVolumes          = LLMOSPrefix + "/on-delete-volumes"
 
 	/*
 		KubeRay related constant

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -30,13 +30,15 @@ var (
 	// LocalLLMServerURL specify local LLM server url, e.g., http://llmos-ollama.llmos-system:11434
 	LocalLLMServerURL = NewSetting(LocalLLMServerURLSettingName, "")
 	// DatabaseURL set local database url, e.g., postgresql://user:password@llmos-postgresql.llmos-system:5432/llmos
-	DatabaseURL           = NewSetting(DatabaseUrlSettingName, "")
-	DefaultNotebookImages = NewSetting(DefaultNotebookImagesSettingName, setDefaultNotebookImages())
-	UpgradeCheckEnabled   = NewSetting(UpgradeCheckEnabledName, "true")
-	UpgradeCheckUrl       = NewSetting(UpgradeCheckUrlName, "https://llmos-upgrade.1block.ai/v1/versions")
-	LLMOSDefaultRegistry  = NewSetting(LLMOSDefaultRegistryName, "docker.io/llmosai")
-	LogLevel              = NewSetting(LogLevelSettingName, "info") // options are info, debug and trace
-	ManagedAddonConfigs   = NewSetting(ManagedAddonConfigsName, "")
+	DatabaseURL              = NewSetting(DatabaseUrlSettingName, "")
+	DefaultNotebookImages    = NewSetting(DefaultNotebookImagesSettingName, setDefaultNotebookImages())
+	UpgradeCheckEnabled      = NewSetting(UpgradeCheckEnabledName, "true")
+	UpgradeCheckUrl          = NewSetting(UpgradeCheckUrlName, "https://llmos-upgrade.1block.ai/v1/versions")
+	LLMOSDefaultRegistry     = NewSetting(LLMOSDefaultRegistryName, "docker.io/llmosai")
+	LogLevel                 = NewSetting(LogLevelSettingName, "info") // options are info, debug and trace
+	ManagedAddonConfigs      = NewSetting(ManagedAddonConfigsName, "")
+	ModelServiceDefaultImage = NewSetting(ModelServiceDefaultImageName, "vllm/vllm-openai:v0.6.4.post1")
+	RayClusterDefaultVersion = NewSetting(RayClusterDefaultVersionName, "2.35.0")
 )
 
 const (
@@ -52,6 +54,8 @@ const (
 	LLMOSDefaultRegistryName         = "llmos-default-registry"
 	LogLevelSettingName              = "log-level"
 	ManagedAddonConfigsName          = "managed-addon-configs"
+	ModelServiceDefaultImageName     = "model-service-default-image"
+	RayClusterDefaultVersionName     = "ray-cluster-default-version"
 )
 
 func init() {


### PR DESCRIPTION
<!-- **IMPORTANT: Please do not create a Pull Request without creating an issue first.** -->

**Description:**
- Add more settings of `model-service-default-image` and `ray-cluster-default-version`
- Support clean-up volumes when deleting the workload.

**Related Issue:**
https://github.com/llmos-ai/llmos/issues/30

**Test plan:**
<!-- Make sure tests pass on the CI. -->
