### PR TITLE
Add proxy API & update modelservice metadata spec

### DIFF
--- a/deploy/charts/llmos-crd/templates/ml.llmos.ai_modelservices.yaml
+++ b/deploy/charts/llmos-crd/templates/ml.llmos.ai_modelservices.yaml
@@ -61,6 +61,8 @@ spec:
                 type: object
               enableGUI:
                 type: boolean
+              libraryName:
+                type: string
               model:
                 type: string
               modelRegistry:
@@ -68,6 +70,8 @@ spec:
                 - huggingface
                 - modelscope
                 - local
+                type: string
+              pipelineTag:
                 type: string
               replicas:
                 format: int32
@@ -127,6 +131,10 @@ spec:
                 default: ClusterIP
                 description: Service Type string describes ingress methods for a service
                 type: string
+              tags:
+                items:
+                  type: string
+                type: array
               template:
                 properties:
                   spec:

--- a/pkg/apis/ml.llmos.ai/v1/modelservice_types.go
+++ b/pkg/apis/ml.llmos.ai/v1/modelservice_types.go
@@ -64,6 +64,15 @@ type ModelServiceSpec struct {
 
 	// +optional, enable gradio GUI of the model
 	EnableGUI bool `json:"enableGUI,omitempty"`
+
+	// +optional, tags of the model
+	Tags []string `json:"tags,omitempty"`
+
+	// +optional, pipeline tag of the model
+	PipelineTag string `json:"pipelineTag,omitempty"`
+
+	// +optional, library name of the model, e.g., transformers, diffusers, etc.
+	LibraryName string `json:"libraryName,omitempty"`
 }
 
 type ModelServiceTemplateSpec struct {

--- a/pkg/apis/ml.llmos.ai/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/ml.llmos.ai/v1/zz_generated_deepcopy.go
@@ -112,6 +112,11 @@ func (in *ModelServiceSpec) DeepCopyInto(out *ModelServiceSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Tags != nil {
+		in, out := &in.Tags, &out.Tags
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -36,6 +36,9 @@ func (r *Router) Routes() http.Handler {
 	authHandler := auth.NewAuthHandler(r.scaled)
 	m.Path("/v1-public/auth").Handler(authHandler)
 
+	proxyHandler := proxy.NewHandler()
+	m.PathPrefix("/proxy").Handler(proxyHandler)
+
 	m.Handle("/", http.RedirectHandler("/dashboard/", http.StatusFound))
 
 	vueUI := ui.Vue
@@ -52,9 +55,6 @@ func (r *Router) Routes() http.Handler {
 		}
 		http.Redirect(rw, req, url, http.StatusFound)
 	})
-
-	localLLMHandler := proxy.NewHandler()
-	m.PathPrefix(proxy.LocalLLMApiPrefix).Handler(localLLMHandler)
 
 	// public handlers
 	publicHandler := publicui.NewPublicHandler()

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -28,8 +28,6 @@ var (
 	UIPath                       = NewSetting("ui-path", "/usr/share/llmos/llmos-operator")
 	UIPl                         = NewSetting(UIPlSettingName, "llmos")    // UIPl is the private vendor/company name
 	UISource                     = NewSetting(UISourceSettingName, "auto") // Options are 'auto', 'external' or 'bundled'
-	// LocalLLMServerURL specify local LLM server url, e.g., http://llmos-ollama.llmos-system:11434
-	LocalLLMServerURL = NewSetting(LocalLLMServerURLSettingName, "")
 	// DatabaseURL set local database url, e.g., postgresql://user:password@llmos-postgresql.llmos-system:5432/llmos
 	DatabaseURL               = NewSetting(DatabaseUrlSettingName, "")
 	DefaultNotebookImages     = NewSetting(DefaultNotebookImagesSettingName, setDefaultNotebookImages())
@@ -40,13 +38,13 @@ var (
 	ModelServiceDefaultImage  = NewSetting(ModelServiceDefaultImageName, "llmos-ai/mirrored-vllm-vllm-openai:v0.6.4.post1")
 	RayClusterDefaultVersion  = NewSetting(RayClusterDefaultVersionName, "2.42.1")
 	GlobalSystemImageRegistry = NewSetting(GlobalSystemImageRegistryName, "")
+	HuggingFaceEndpoint       = NewSetting(HuggingFaceEndpointName, "")
 )
 
 const (
 	UIPlSettingName                  = "ui-pl"
 	UISourceSettingName              = "ui-source"
 	FirstLoginSettingName            = "first-login"
-	LocalLLMServerURLSettingName     = "local-llm-server-url"
 	DatabaseUrlSettingName           = "database-url"
 	DefaultNotebookImagesSettingName = "default-notebook-images"
 	ServerVersionName                = "server-version"
@@ -57,6 +55,7 @@ const (
 	ModelServiceDefaultImageName     = "model-service-default-image"
 	RayClusterDefaultVersionName     = "ray-cluster-default-version"
 	GlobalSystemImageRegistryName    = "global-system-image-registry"
+	HuggingFaceEndpointName          = "huggingface-endpoint"
 )
 
 func init() {

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -2,19 +2,11 @@ package utils
 
 import (
 	"fmt"
-	"net/url"
 	"strings"
 	"unicode"
 
 	"gopkg.in/yaml.v3"
-
-	"github.com/llmos-ai/llmos-operator/pkg/settings"
 )
-
-func GetLocalLLMUrl() (*url.URL, error) {
-	localLLMUrl := settings.LocalLLMServerURL.Get()
-	return url.Parse(localLLMUrl)
-}
 
 // ReplaceAndLower replaces underscores and colons with hyphens and converts the string to lowercase.
 func ReplaceAndLower(s string) string {


### PR DESCRIPTION
<!-- **IMPORTANT: Please do not create a Pull Request without creating an issue first.** -->

**Problem:**
ModelService lacks comprehensive metadata support, making it difficult for users to manage and track model info and relevant details. This limitation affects usability, especially when dealing with multiple models in a production environment.

**Solution:**
- Add fields like `tags`, `pipelineTag` and `libraryName` to the modelservice spec.
- Implement a proxy handler to allow users to fetch model list and details from the original API.
- Add a global `huggingface-endpoint` setting for configuring an HF proxy.

**Related Issue:**
https://github.com/llmos-ai/llmos/issues/47


### **Testing Plan**  

#### **General Testing**  
1. Apply the updated CRD using:  
   ```sh
   make install-crds
   ```  
2. Update the API server image to:  
   ```
   ghcr.io/guangbochen/llmos-operator:main-head
   ```  
3. Set the `huggingface-endpoint` value to `https://hf-mirror.com` and verify that it is correctly saved.  
4. Access the proxy API using:  
   ```
   https://myip:8443/proxy?url=https://huggingface.co/api/models?limit=100
   ```  
   - Ensure it returns a valid JSON response containing the model list.  

#### **Update ModelService Spec**  
1. Apply a `ModelService` configuration with the newly added fields:  
   ```yaml
   spec:
     model: deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
     modelRegistry: modelscope
     replicas: 1
     selector:
       matchLabels:
         ml.llmos.ai/model-service-name: llm-qwen
         ml.llmos.ai/type: model-service
     serviceType: NodePort
     tags:  # Newly added metadata fields
       - transformers
       - safetensors
       - deepseek_v3
       - text-generation
       - conversational
       - custom_code
       - arxiv:2412.19437
       - license:mit
       - autotrain_compatible
       - endpoints_compatible
       - fp8
       - region:us
     libraryName: transformers  # New field
     pipelineTag: text-generation  # New field
   ```  
2. Confirm that the new fields are correctly stored in the `ModelService` configuration.  

Let me know if you need further refinements! 🚀

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded model service configuration with additional metadata options for library identification, pipeline tagging, and flexible tag assignment.
  - Introduced an improved proxy endpoint for handling client requests with enhanced validation and error messaging.
  - Updated configuration settings by replacing the legacy local server option with a new integration endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->