### PR TITLE
Fix incorrect passing of ModelService arguments & update default vllm version

### DIFF
--- a/pkg/controller/master/modelservice/common_test.go
+++ b/pkg/controller/master/modelservice/common_test.go
@@ -1,0 +1,70 @@
+package modelservice
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	mlv1 "github.com/llmos-ai/llmos-operator/pkg/apis/ml.llmos.ai/v1"
+)
+
+func TestBuildArgs(t *testing.T) {
+	ms := &mlv1.ModelService{}
+	ms.Spec.ModelName = "test-model"
+	ms.Spec.ServedModelName = "served-test-model"
+	ms.Spec.Template.Spec.Containers = []v1.Container{
+		{
+			Args: []string{"--some-arg=value", "--model=old-model"},
+			Resources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					vGPUNumber: resource.MustParse("1"),
+				},
+			},
+		},
+	}
+
+	expectedArgs := []string{
+		"--some-arg=value",
+		"--model=test-model",
+		"--served-model-name=served-test-model",
+		"--tensor-parallel-size=" + strconv.Itoa(getVGPUNumber(ms)),
+	}
+
+	result := buildArgs(ms)
+
+	if !reflect.DeepEqual(result, expectedArgs) {
+		t.Errorf("Expected %v, got %v", expectedArgs, result)
+	}
+}
+
+func TestBuildArgs_WithoutServedModelName(t *testing.T) {
+	ms := &mlv1.ModelService{}
+	ms.Spec.ModelName = "test-model"
+	ms.Spec.ServedModelName = ""
+	ms.Spec.Template.Spec.Containers = []v1.Container{
+		{
+			Args: []string{"--some-arg=value", "--model=old-model", "--served-model-name=my-name"},
+			Resources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					vGPUNumber: resource.MustParse("1"),
+				},
+			},
+		},
+	}
+
+	expectedArgs := []string{
+		"--some-arg=value",
+		"--model=test-model",
+		"--served-model-name=my-name",
+		"--tensor-parallel-size=" + strconv.Itoa(getVGPUNumber(ms)),
+	}
+
+	result := buildArgs(ms)
+
+	if !reflect.DeepEqual(result, expectedArgs) {
+		t.Errorf("Expected %v, got %v", expectedArgs, result)
+	}
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -37,7 +37,7 @@ var (
 	UpgradeCheckUrl           = NewSetting(UpgradeCheckUrlName, "https://llmos-upgrade.1block.ai/v1/versions")
 	LogLevel                  = NewSetting(LogLevelSettingName, "info") // options are info, debug and trace
 	ManagedAddonConfigs       = NewSetting(ManagedAddonConfigsName, "")
-	ModelServiceDefaultImage  = NewSetting(ModelServiceDefaultImageName, "llmos-ai/mirrored-vllm-vllm-openai:v0.6.4.post1")
+	ModelServiceDefaultImage  = NewSetting(ModelServiceDefaultImageName, "llmos-ai/mirrored-vllm-vllm-openai:v0.8.2")
 	RayClusterDefaultVersion  = NewSetting(RayClusterDefaultVersionName, "2.42.1")
 	GlobalSystemImageRegistry = NewSetting(GlobalSystemImageRegistryName, "")
 )


### PR DESCRIPTION
<!-- **IMPORTANT: Please do not create a Pull Request without creating an issue first.** -->

**Problem:**

- Fix incorrect passing of ModelService arguments.  
- Update the default vLLM image version to `v0.8.2`.  

**Solution:**  
- Refactor `buildArgs` logic and add unit tests.  
- Set `ModelServiceDefaultImage` to `v0.8.2`.  

**Related Issue:**  
https://github.com/llmos-ai/llmos/issues/48


**Test Plan:**  
1. Navigate to the **Model Services** page.  
2. Create a new model service (e.g., with the model name `Qwen/Qwen2.5-VL-3B-Instruct`).  
3. In the **Arguments** field, add `--model-impl=vllm`.  
4. Ensure that the argument is correctly passed to the server container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified how container arguments are initialized for better clarity and consistency.
- **Tests**
  - Introduced tests to ensure the new argument handling behaves as expected.
- **Chores**
  - Updated the default model service image to a newer version for improved deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->