### PR TITLE
fix: ctx could not be nil for model handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,8 +61,6 @@ require (
 	github.com/k3s-io/helm-controller v0.16.3
 	github.com/minio/minio-go/v7 v7.0.89
 	github.com/oneblock-ai/webhook v0.0.0-20240122084603-b51d23225312
-	github.com/onsi/ginkgo/v2 v2.20.0
-	github.com/onsi/gomega v1.34.1
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/apiserver v0.0.0-20240708202538-39a6f2535146
 	github.com/rancher/dynamiclistener v1.27.5
@@ -121,7 +119,6 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1073,6 +1073,7 @@ github.com/go-pdf/fpdf v0.5.0/go.mod h1:HzcnA+A23uwogo0tp9yU+l3V+KXhiESpt1PMayhO
 github.com/go-pdf/fpdf v0.6.0/go.mod h1:HzcnA+A23uwogo0tp9yU+l3V+KXhiESpt1PMayhOh5M=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=

--- a/pkg/api/model/handler.go
+++ b/pkg/api/model/handler.go
@@ -25,6 +25,7 @@ func NewHandler(scaled *config.Scaled) Handler {
 	secretCache := scaled.CoreFactory.Core().V1().Secret().Cache()
 
 	h.BaseHandler = cr.BaseHandler{
+		Ctx:                    scaled.Ctx,
 		GetRegistryAndRootPath: h.GetRegistryAndRootPath,
 		RegistryManager:        registry.NewManager(secretCache, registryCache),
 	}


### PR DESCRIPTION
<!-- **IMPORTANT: Please do not create a Pull Request without creating an issue first.** -->

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
The context of the model handler will be an input parameter of the S3 operation such as list. If it's nil, the S3 operation will be panic. 

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Pass the Scaled.Ctx.

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the CI. -->
- Create a model.
- Test the model APIs(list, createDirectory, upload, download, remove)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed unused dependencies to streamline the application.

- **Refactor**
	- Improved internal initialization of handlers for better context propagation. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->