### PR TITLE
chore: bump default vllm version to v0.10.0

### DIFF
--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -35,7 +35,7 @@ var (
 	UpgradeCheckUrl           = NewSetting(UpgradeCheckUrlName, "https://llmos-upgrade.1block.ai/v1/versions")
 	LogLevel                  = NewSetting(LogLevelSettingName, "info") // options are info, debug and trace
 	ManagedAddonConfigs       = NewSetting(ManagedAddonConfigsName, "")
-	ModelServiceDefaultImage  = NewSetting(ModelServiceDefaultImageName, "llmos-ai/mirrored-vllm-vllm-openai:v0.8.5-post1")
+	ModelServiceDefaultImage  = NewSetting(ModelServiceDefaultImageName, "docker.io/vllm/vllm-openai:v0.10.0")
 	RayClusterDefaultVersion  = NewSetting(RayClusterDefaultVersionName, "2.42.1")
 	GlobalSystemImageRegistry = NewSetting(GlobalSystemImageRegistryName, "")
 	HuggingFaceEndpoint       = NewSetting(HuggingFaceEndpointName, "")

--- a/sample/serving/gemma2.yaml
+++ b/sample/serving/gemma2.yaml
@@ -13,7 +13,6 @@ spec:
       runtimeClassName: nvidia
       containers:
         - name: server
-          image: vllm/vllm-openai:latest
           ports:
             - containerPort: 8000
               protocol: TCP

--- a/sample/serving/local-qwen3.yaml
+++ b/sample/serving/local-qwen3.yaml
@@ -19,7 +19,7 @@ spec:
             - '--dtype=half'
             - '--enable-reasoning'
             - '--reasoning-parser=deepseek_r1'
-          image: docker.io/vllm/vllm-openai:v0.8.5
+          image: docker.io/vllm/vllm-openai:v0.10.0
           name: server
           ports:
             - containerPort: 8000


### PR DESCRIPTION
<!-- **IMPORTANT: Please do not create a Pull Request without creating an issue first.** -->

**Problem:**
Bump the LLMOS model service engine to a newer version.

**Solution:**
Bump default vllm version to [v0.10.0](https://github.com/vllm-project/vllm/releases/tag/v0.10.0)

**Related Issue:**
https://github.com/llmos-ai/llmos/issues/46

**Test plan:**
- The new model service should be up and running correctly with the latest VLLM image.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the default container image for the model service to a newer version, improving compatibility and features.
* **Chores**
  * Refreshed sample configuration files to use the latest container image version or remove outdated image references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->