### PR TITLE
feat(datacollection): add sync files action and skip redundant updates

### DIFF
--- a/pkg/api/datacollection/handler.go
+++ b/pkg/api/datacollection/handler.go
@@ -3,6 +3,7 @@ package datacollection
 import (
 	"fmt"
 	"net/http"
+	"reflect"
 
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
@@ -43,6 +44,7 @@ func NewHandler(scaled *config.Scaled) Handler {
 		PostHooks: map[string]cr.PostHook{
 			cr.ActionUpload: h.SyncFiles,
 			cr.ActionRemove: h.SyncFiles,
+			cr.ActionSyncFiles: h.SyncFiles,
 		},
 	}
 
@@ -77,6 +79,9 @@ func (h Handler) SyncFiles(req *http.Request, b backend.Backend) error {
 		})
 	}
 
+	if reflect.DeepEqual(dc.Status.Files, fileInfos) {
+		return nil
+	}
 	dcCopy := dc.DeepCopy()
 	dcCopy.Status.Files = fileInfos
 	if _, err = h.dcClient.UpdateStatus(dcCopy); err != nil {

--- a/pkg/api/datacollection/schema.go
+++ b/pkg/api/datacollection/schema.go
@@ -23,6 +23,7 @@ func Formatter(request *types.APIRequest, resource *types.RawResource) {
 	resource.AddAction(request, cr.ActionList)
 	resource.AddAction(request, cr.ActionRemove)
 	resource.AddAction(request, cr.ActionGeneratePresignedURL)
+	resource.AddAction(request, cr.ActionSyncFiles)
 }
 
 func RegisterSchema(scaled *config.Scaled, server *server.Server) error {
@@ -48,12 +49,14 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server) error {
 			cr.ActionGeneratePresignedURL: {
 				Input: "generatePresignedURLInput",
 			},
+			cr.ActionSyncFiles: {},
 		}
 		s.ActionHandlers = map[string]http.Handler{
 			cr.ActionUpload:               h,
 			cr.ActionList:                 h,
 			cr.ActionRemove:               h,
 			cr.ActionGeneratePresignedURL: h,
+			cr.ActionSyncFiles:            h,
 		}
 	}
 


### PR DESCRIPTION
If the user directly uploads a file, it is necessary to call the synFiles api to synchronize the fileinfo to datacollection status.

<!-- **IMPORTANT: Please do not create a Pull Request without creating an issue first.** -->

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
If users generates upload URL to upload files directly to datacollection, the datacollection status will not contains these files. 

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add a new API syncFiles. After uploading files directly, call the syncFiles API to sync the file info into datacollection status.

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the CI. -->
