### PR TITLE
fix(notebook): skip validation when onDeleteVolumes annotation is set

### DIFF
--- a/pkg/api/datacollection/handler.go
+++ b/pkg/api/datacollection/handler.go
@@ -42,8 +42,8 @@ func NewHandler(scaled *config.Scaled) Handler {
 		GetRegistryAndRootPath: h.GetRegistryAndRootPath,
 		RegistryManager:        registry.NewManager(secretCache.Get, registryCache.Get),
 		PostHooks: map[string]cr.PostHook{
-			cr.ActionUpload: h.SyncFiles,
-			cr.ActionRemove: h.SyncFiles,
+			cr.ActionUpload:    h.SyncFiles,
+			cr.ActionRemove:    h.SyncFiles,
 			cr.ActionSyncFiles: h.SyncFiles,
 		},
 	}

--- a/pkg/webhook/resources/notebook/validator.go
+++ b/pkg/webhook/resources/notebook/validator.go
@@ -46,6 +46,12 @@ func (v *validator) Update(_ *admission.Request, _, newObj runtime.Object) error
 		return nil
 	}
 
+	// nolint:lll
+	// Workaround for https://github.com/llmos-ai/llmos-operator/blob/3ae5a383806bb36dbca2eff0ccc1b2ba698699f9/pkg/controller/master/notebook/notebook_controller.go#L103
+	if len(notebook.Annotations[constant.AnnotationOnDeleteVolumes]) > 0 {
+		return nil
+	}
+
 	if err := v.validateDatasetMountings(notebook); err != nil {
 		return err
 	}


### PR DESCRIPTION
Add workaround to bypass dataset mounting validation when the notebook has the onDeleteVolumes annotation set, as it's handled separately in the controller

<!-- **IMPORTANT: Please do not create a Pull Request without creating an issue first.** -->

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
When deleting notebook, UI will add the onDeleteVolumes annotation to delete PVC. The validator will deny the update operation. 

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Skip validation when onDeleteVolumes annotation is set

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the CI. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notebook update handling by skipping certain validations when a specific annotation is present, ensuring smoother operations in these scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->