### PR TITLE
make kubernetesVersion required and improve upgrade agemt logic

### DIFF
--- a/deploy/charts/llmos-crd/templates/management.llmos.ai_upgrades.yaml
+++ b/deploy/charts/llmos-crd/templates/management.llmos.ai_upgrades.yaml
@@ -120,6 +120,7 @@ spec:
                     type: integer
                 type: object
               kubernetesVersion:
+                description: Specify the Kubernetes version to upgrade to
                 type: string
               registry:
                 type: string
@@ -127,6 +128,7 @@ spec:
                 description: The LLMOS Operator version to upgrade to
                 type: string
             required:
+            - kubernetesVersion
             - version
             type: object
           status:

--- a/pkg/apis/management.llmos.ai/v1/upgrade_types.go
+++ b/pkg/apis/management.llmos.ai/v1/upgrade_types.go
@@ -59,8 +59,9 @@ type UpgradeSpec struct {
 	// The LLMOS Operator version to upgrade to
 	Version string `json:"version"`
 
-	// +Optional, Specify the Kubernetes version to upgrade to
-	KubernetesVersion string `json:"kubernetesVersion,omitempty"`
+	// +kubebuilder:validation:Required
+	// Specify the Kubernetes version to upgrade to
+	KubernetesVersion string `json:"kubernetesVersion"`
 
 	// +Optional, override the default image registry if provided
 	Registry string `json:"registry,omitempty"`

--- a/sample/upgrade/upgrade.yaml
+++ b/sample/upgrade/upgrade.yaml
@@ -1,17 +1,17 @@
 apiVersion: management.llmos.ai/v1
 kind: Version
 metadata:
-  name: v0.2.0-rc1
+  name: v0.3.0-rc3
 spec:
-  minUpgradableVersion: v0.1.0
-  kubernetesVersion: v1.31.0+k3s1 # The newer k8s version to upgrade to
-  releaseDate: "2024-09-30"
-  tags: []
+  minUpgradableVersion: v0.2.0
+  kubernetesVersion: v1.33.1+k3s1
+  releaseDate: "2025-08-5"
+  tags: ["rc"]
 ---
 apiVersion: management.llmos.ai/v1
 kind: Upgrade
 metadata:
-  name: llmos-upgrade-test
+  name: upgrade-v030-rc3
 spec:
-  version: v0.2.0-rc1 # The version to upgrade to
-  registry: "docker.io/guangbo" # Override the default registry if needed
+  version: v0.3.0-rc3 # The version to upgrade to
+  registry: "ghcr.io/llmos-ai"


### PR DESCRIPTION
**Problem:**
Handle more upgrade corner cases

**Solution:**
Make kubernetesVersion required and improve upgrade agemt logic
- Change KubernetesVersion field from optional to required in UpgradeSpec
- Update CRD and sample upgrade manifests to reflect new version requirements
- Improve image registry parsing to handle multi-part registry URLs
- Add drain configuration with force option to agent upgrade plan

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the CI. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The Kubernetes version is now a required field when specifying upgrades, ensuring clarity during the upgrade process.

* **Bug Fixes**
  * Improved node drain behavior during agent upgrades for smoother operations.

* **Chores**
  * Updated sample upgrade and version configurations to reflect the latest versions and registry locations.
  * Enhanced documentation for upgrade specifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->