### PR TITLE
update version references and fix upgrade validation logic

### DIFF
--- a/pkg/webhook/resources/upgrade/validator.go
+++ b/pkg/webhook/resources/upgrade/validator.go
@@ -66,8 +66,8 @@ func (v *validator) Create(_ *admission.Request, newObj runtime.Object) error {
 	}
 
 	for _, u := range upgrades {
-		if u.Status.State == condition.StateComplete || u.Status.State == condition.StateError {
-			msg := fmt.Sprintf("Cannot process until previous upgrade %q is complete", upgrades[0].Name)
+		if u.Status.State != condition.StateComplete && u.Status.State != condition.StateError {
+			msg := fmt.Sprintf("Cannot process until previous upgrade %q is complete", u.Name)
 			return werror.StatusConflict(msg)
 		}
 	}

--- a/sample/upgrade/upgrade.yaml
+++ b/sample/upgrade/upgrade.yaml
@@ -1,7 +1,7 @@
 apiVersion: management.llmos.ai/v1
 kind: Version
 metadata:
-  name: v0.3.0-rc3
+  name: v0.3.0-rc4
 spec:
   minUpgradableVersion: v0.2.0
   kubernetesVersion: v1.33.1+k3s1
@@ -11,7 +11,8 @@ spec:
 apiVersion: management.llmos.ai/v1
 kind: Upgrade
 metadata:
-  name: upgrade-v030-rc3
+  name: upgrade-v030-rc4
 spec:
-  version: v0.3.0-rc3 # The version to upgrade to
-  registry: "ghcr.io/llmos-ai"
+  version: v0.3.0-rc4 # The version to upgrade to
+  kubernetesVersion: v1.33.1+k3s1
+  registry: "ghcr.io"


### PR DESCRIPTION


<!-- **IMPORTANT: Please do not create a Pull Request without creating an issue first.** -->

**Problem:**
Update webhook logic is not valid.

**Solution:**
- Update version references from v0.3.0-rc3 to v0.3.0-rc4 in upgrade.yaml 
- Fix upgrade validation logic to correctly check for incomplete upgrades

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the CI. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected upgrade validation logic to ensure processing is blocked only when there is an ongoing upgrade that is neither complete nor errored. Error messages now correctly reference the current upgrade.

* **Chores**
  * Updated sample upgrade resource to version v0.3.0-rc4, specifying the new Kubernetes version and updating the container image registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->